### PR TITLE
feat(questions): trim the access token in case space was added during copy paste

### DIFF
--- a/bin/swan-configure.js
+++ b/bin/swan-configure.js
@@ -13,6 +13,7 @@ const inquirer    = require('inquirer');
 const questions   = {
   'personal access token': {
     message : 'Enter your personal access token:',
+    filter: string => {string.trim()},
     validate: function(input) {
       if (input && input.length === 40) {
         return true;


### PR DESCRIPTION
reason for implementing this is because I had a very anoying bug where i pasted my
token and yet it though it was invalid because of an prepended space.
