### PR TITLE
fix(configure): allow short username

### DIFF
--- a/bin/swan-configure.js
+++ b/bin/swan-configure.js
@@ -15,8 +15,11 @@ const questions   = {
     message : 'What is your github username:',
     default : (config.git) ? config.git.user.name : '',
     validate: function (input) {
-      let valid = typeof input === 'string' && input.length > 0;
-      return valid || `Expected a valid github username.`;
+      if (typeof input === 'string' && /\S+/.test(input)) {
+        return true;
+      }
+
+      return `Expected a valid github username.`;
     }
   },
   'personal access token': {

--- a/bin/swan-configure.js
+++ b/bin/swan-configure.js
@@ -19,7 +19,7 @@ const questions   = {
         return true;
       }
 
-      return `Expected a valid github username.`;
+      return 'Expected a valid github username.';
     }
   },
   'personal access token': {
@@ -30,7 +30,7 @@ const questions   = {
         return true;
       }
 
-      return `Expected the argument to be a personal access token.`;
+      return 'Expected the argument to be a personal access token.';
     }
   },
   protocol: {

--- a/bin/swan-configure.js
+++ b/bin/swan-configure.js
@@ -15,11 +15,8 @@ const questions   = {
     message : 'What is your github username:',
     default : (config.git) ? config.git.user.name : '',
     validate: function (input) {
-      if (input && input.length >= 5) {
-        return true;
-      }
-
-      return `Expected a valid github username.`;
+      let valid = typeof input === 'string' && input.length > 0;
+      return valid || `Expected a valid github username.`;
     }
   },
   'personal access token': {


### PR DESCRIPTION
Allow any username with at least one non-whitespace character (really just a simple check to disregard accidental whitespace).

Fixes #22.
